### PR TITLE
Update compatibility for Django 1.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,8 @@ TODO
 
 CHANGELOG
 =========
+* 0.3
+    * Update with compatibility for Django 1.10
 * 0.2
     * Update with compatibility for Django 1.9
     * Add Migrations

--- a/simple_audit/admin.py
+++ b/simple_audit/admin.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.html import escape
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .models import Audit
 from .signal import MODEL_LIST
 
@@ -46,9 +46,9 @@ class AuditAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(AuditAdmin, self).get_urls()
-        my_urls = patterns('',
+        my_urls = [
             url(r'^revert/(?P<audit_id>\d+)/$', self.admin_site.admin_view(self.revert_change), name='simple_audit_audit_revert')
-        )
+        ]
         return my_urls + urls
 
     def revert_change(self, request, audit_id):


### PR DESCRIPTION
- [x] Per Django release notes, drop `patterns` in favor of saving urlpatterns in a list.

> Because patterns() is a function call, it accepts a maximum of 255 arguments (URL patterns, in this case). This is a limit for all Python function calls. This is rarely a problem in practice, because you’ll typically structure your URL patterns modularly by using include() sections. However, on the off-chance you do hit the 255-argument limit, realize that patterns() returns a Python list, so you can split up the construction of the list.

[https://docs.djangoproject.com/en/1.9/ref/urls/#url](https://docs.djangoproject.com/en/1.9/ref/urls/#url)