### PR TITLE
Python3-ifies django_simple_audit/admin.py

### DIFF
--- a/simple_audit/admin.py
+++ b/simple_audit/admin.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*_
+from __future__ import absolute_import
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.contrib.contenttypes.models import ContentType
@@ -78,7 +79,7 @@ class AuditAdmin(admin.ModelAdmin):
     audit_description.short_description = _("Description")
 
     def audit_content(self, audit):
-        obj_string = audit.obj_description or unicode(audit.content_object)
+        obj_string = audit.obj_description or str(audit.content_object)
 
         return "<a title='%(filter)s' href='%(base)s?content_type__id__exact=%(type_id)s&object_id__exact=%(id)s'>%(type)s: %(obj)s</a>" % {
             'filter': _("Click to filter"),


### PR DESCRIPTION
Audit records give us a record of changes for some sensitive DB records.

Sentry Issue: [PRODUCTION-1NK](https://sentry.io/stratasancom/production/issues/730384901/)

```
KeyError: 'audit_content'
  File "django/db/models/options.py", line 617, in get_field
    return self.fields_map[field_name]

FieldDoesNotExist: Audit has no field named 'audit_content'
  File "django/contrib/admin/utils.py", line 283, in lookup_field
    f = _get_non_gfk_field(opts, name)
  File "django/contrib/admin/utils.py", line 317, in _get_non_gfk_field
    field = opts.get_field(name)
  File "django/db/models/options.py", line 619, in get_field
    raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, field_name))

NameError: name 'unicode' is not defined
(29 additional frame(s) were not displayed)
...
  File "simple_audit/admin.py", line 81, in audit_content
    obj_string = audit.obj_description or unicode(audit.content_object)

NameError: name 'unicode' is not defined
```

This PR solves that in our fork.