### PR TITLE
Update to Django 2, adding Foreign Key on_delete specification

### DIFF
--- a/simple_audit/models.py
+++ b/simple_audit/models.py
@@ -40,10 +40,10 @@ class Audit(models.Model):
     )
     date = models.DateTimeField(auto_now_add=True, verbose_name=_("Date"))
     operation = models.PositiveIntegerField(choices=OPERATION_CHOICES, verbose_name=_('Operation'))
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField(db_index=True)
     content_object = GenericForeignKey('content_type', 'object_id')
-    audit_request = models.ForeignKey("AuditRequest", null=True)
+    audit_request = models.ForeignKey("AuditRequest", , on_delete=models.CASCADE, null=True)
     description = models.TextField()
     obj_description = models.CharField(max_length=100, db_index=True, null=True, blank=True)
 
@@ -75,7 +75,7 @@ class Audit(models.Model):
 
 
 class AuditChange(models.Model):
-    audit = models.ForeignKey(Audit, related_name='field_changes')
+    audit = models.ForeignKey(Audit, on_delete=models.CASCADE, related_name='field_changes')
     field = models.CharField(max_length=255)
     old_value = models.TextField(null=True, blank=True)
     new_value = models.TextField(null=True, blank=True)
@@ -95,7 +95,7 @@ class AuditRequest(models.Model):
     ip = models.GenericIPAddressField()
     path = models.CharField(max_length=1024)
     date = models.DateTimeField(auto_now_add=True, verbose_name=_("Date"))
-    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), on_delete=models.CASCADE)
 
     class Meta:
         db_table = 'audit_request'


### PR DESCRIPTION
With the update to django 2, Foreign Keys now are required to have on_delete method specified. I implemented `on_delete=models.CASCADE`, since that was the default for django 1.11