### PR TITLE
Removing call on is_anonymous property, and black reformatting

### DIFF
--- a/simple_audit/middleware.py
+++ b/simple_audit/middleware.py
@@ -4,28 +4,31 @@ from django.utils.deprecation import MiddlewareMixin
 from .models import AuditRequest
 from . import settings
 
+
 class TrackingRequestOnThreadLocalMiddleware(MiddlewareMixin):
     """Middleware that gets various objects from the
     request object and saves them in thread local storage."""
 
     def _get_ip(self, request):
         # get real ip
-        if 'HTTP_X_FORWARDED_FOR' in request.META:
-            ip = request.META['HTTP_X_FORWARDED_FOR']
-        elif 'Client-IP' in request.META:
-            ip = request.META['Client-IP']
+        if "HTTP_X_FORWARDED_FOR" in request.META:
+            ip = request.META["HTTP_X_FORWARDED_FOR"]
+        elif "Client-IP" in request.META:
+            ip = request.META["Client-IP"]
         else:
-            ip = request.META['REMOTE_ADDR']
+            ip = request.META["REMOTE_ADDR"]
         ip = ip.split(",")[0]
         return ip
 
     def process_request(self, request):
-        if not request.user.is_anonymous():
+        if not request.user.is_anonymous:
             ip = self._get_ip(request)
             AuditRequest.new_request(request.get_full_path(), request.user, ip)
         else:
             if settings.DJANGO_SIMPLE_AUDIT_REST_FRAMEWORK_AUTHENTICATOR:
-                user_auth_tuple = settings.DJANGO_SIMPLE_AUDIT_REST_FRAMEWORK_AUTHENTICATOR().authenticate(request)
+                user_auth_tuple = settings.DJANGO_SIMPLE_AUDIT_REST_FRAMEWORK_AUTHENTICATOR().authenticate(
+                    request
+                )
 
                 if user_auth_tuple is not None:
                     user, token = user_auth_tuple


### PR DESCRIPTION
Change because of this sentry error: https://sentry.io/organizations/stratasancom/issues/1300265910/?project=8726&referrer=slack that we got after deploying the django 2.2.5 upgrade branch to staging
